### PR TITLE
removed `this.inherited(arguments)` call from constructor

### DIFF
--- a/widgets/locate/TRSsearch.js
+++ b/widgets/locate/TRSsearch.js
@@ -160,8 +160,6 @@ define([
             // summary:
             //      description
             console.log('agrc.widgets.locate.TrsSeearch::constructor', arguments);
-
-            this.inherited(arguments);
         },
         postCreate: function() {
             // summary:


### PR DESCRIPTION
Ran into this problem with a widget that inherited from the TRSsearch widget. This change solved the problem. If I am reading [the docs](http://dojotoolkit.org/reference-guide/1.8/dojo/_base/declare.html#id17) correctly, I'm thinking that we should remove this from all of our widgets if it's there.

@steveoh: What do you think?
