### PR TITLE
Remove hard coded http://

### DIFF
--- a/_SpecRunner.html
+++ b/_SpecRunner.html
@@ -7,6 +7,9 @@
   <link rel="stylesheet" type="text/css" href=".grunt/grunt-contrib-jasmine/jasmine.css">
 
 
+</head>
+<body>
+
   
   <script src=".grunt/grunt-contrib-jasmine/es5-shim.js"></script>
   
@@ -39,7 +42,5 @@
   <script src=".grunt/grunt-contrib-jasmine/reporter.js"></script>
   
 
-</head>
-<body>
 </body>
 </html>

--- a/modules/WebAPI.js
+++ b/modules/WebAPI.js
@@ -15,7 +15,7 @@ define([
         //      A convenience class for using [AGRC's web api](http://api.mapserv.utah.gov).
 
         // baseUrl: String
-        baseUrl: 'http://api.mapserv.utah.gov/api/v1/',
+        baseUrl: '//api.mapserv.utah.gov/api/v1/',
 
 
         // Properties to be sent into constructor

--- a/widgets/locate/FindAddress.js
+++ b/widgets/locate/FindAddress.js
@@ -186,7 +186,7 @@ define([
             //     Deferred
             console.info('agrc.widgets.locate.FindAddress::_invokeWebService', arguments);
 
-            var url = 'http://api.mapserv.utah.gov/api/v1/Geocode/{geocode.street}/{geocode.zone}';
+            var url = '//api.mapserv.utah.gov/api/v1/Geocode/{geocode.street}/{geocode.zone}';
 
             var options = {
                 apiKey: this.apiKey

--- a/widgets/locate/FindGeneric.js
+++ b/widgets/locate/FindGeneric.js
@@ -112,7 +112,7 @@ define([
 
         // _searchUrlTemplate: [private] String
         //      the template url to the agrc map service that the validation text box points at;
-        _searchUrlTemplate: 'http://mapserv.utah.gov/WSUT/GetFeatureAttributes.svc/find-generic-widget/layer' +
+        _searchUrlTemplate: '//mapserv.utah.gov/WSUT/GetFeatureAttributes.svc/find-generic-widget/layer' +
             '({layerName})returnAttributes({searchFieldName})where({searchFieldName})(=)( )?dojo',
 
         // _envelopeUrl: [private] String
@@ -121,7 +121,7 @@ define([
 
         // _envelopeUrlTemplate: [private] String
         //      The template url to the agrc map service that returns the feature envelope.
-        _envelopeUrlTemplate: 'http://mapserv.utah.gov/WSUT/FeatureGeometry.svc/GetEnvelope/find-generic-widget/layer' +
+        _envelopeUrlTemplate: '//mapserv.utah.gov/WSUT/FeatureGeometry.svc/GetEnvelope/find-generic-widget/layer' +
             '({layerName})where({searchFieldName})(=)([searchValue])quotes=true',
 
         // _store: dojo.data.Store

--- a/widgets/locate/FindRouteMilepost.js
+++ b/widgets/locate/FindRouteMilepost.js
@@ -174,7 +174,7 @@ define([
                 console.log('agrc.widgets.locate.FindRouteMilepost::_invokeWebService', arguments);
                 var that = this;
 
-                var url = 'http://api.mapserv.utah.gov/api/v1/geocode/milepost/${route}/${milepost}?apiKey=${key}';
+                var url = '//api.mapserv.utah.gov/api/v1/geocode/milepost/${route}/${milepost}?apiKey=${key}';
                 var params = {
                     url: string.substitute(url, {
                         milepost: this.milepostTxt.value,

--- a/widgets/map/BaseMap.js
+++ b/widgets/map/BaseMap.js
@@ -191,7 +191,7 @@ define([
             }
 
             // replace default link on logo
-            esriConfig.defaults.map.logoLink = 'http://gis.utah.gov/';
+            esriConfig.defaults.map.logoLink = '//gis.utah.gov/';
 
             // not sure if this is needed?
             domClass.add(mapDiv, 'mapContainer');
@@ -290,7 +290,7 @@ define([
             console.log('agrc.widgets.map.BaseMap::addAGRCBaseMap', arguments);
 
             // build basemap url
-            var url = 'http://mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/' + cacheName + '/MapServer';
+            var url = '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/' + cacheName + '/MapServer';
             var lyr = new ArcGISTiledMapServiceLayer(url, {
                 id: cacheName
             });

--- a/widgets/map/resources/defaultThemeInfos.js
+++ b/widgets/map/resources/defaultThemeInfos.js
@@ -2,43 +2,43 @@ define([], function() {
         return [{
             label: 'Terrain',
             layers: [{
-                url: 'http://mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Terrain/MapServer',
+                url: '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Terrain/MapServer',
                 opacity: 1
             }]
         }, {
             label: 'Hybrid',
             layers: [{
-                url: 'http://mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Hybrid/MapServer',
+                url: '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Hybrid/MapServer',
                 opacity: 1
             }]
         }, {
             label: 'Streets',
             layers: [{
-                url: 'http://mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Vector/MapServer',
+                url: '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Vector/MapServer',
                 opacity: 1
             }]
         }, {
             label: 'Imagery',
             layers: [{
-                url: 'http://mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Imagery/MapServer',
+                url: '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Imagery/MapServer',
                 opacity: 1
             }]
         }, {
             label: 'Topo',
             layers: [{
-                url: 'http://mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Topo/MapServer',
+                url: '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Topo/MapServer',
                 opacity: 1
             }]
         }, {
             label: 'Lite',
             layers: [{
-                url: 'http://mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Lite/MapServer',
+                url: '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Lite/MapServer',
                 opacity: 1
             }]
         }, {
             label: 'Hillshade',
             layers: [{
-                url: 'http://mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Hillshade/MapServer',
+                url: '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Hillshade/MapServer',
                 opacity: 1
             }]
         }];

--- a/widgets/tests/BaseMapTests.html
+++ b/widgets/tests/BaseMapTests.html
@@ -8,8 +8,8 @@
     <meta name="keywords" content="agrc.widgets.map.BaseMap, esri.map, basemap, map, tests, test, javascript" />
 
     <!-- CSS -->
-    <link rel="stylesheet" href="http://serverapi.arcgisonline.com/jsapi/arcgis/3.4/js/dojo/dijit/themes/claro/claro.css">
-    <link rel="stylesheet" href="http://serverapi.arcgisonline.com/jsapi/arcgis/3.4/js/esri/css/esri.css">
+    <link rel="stylesheet" href="//js.arcgis.com/3.9/js/dojo/dijit/themes/claro/claro.css">
+    <link rel="stylesheet" href="//js.arcgis.com/3.9/js/esri/css/esri.css">
     <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.1/css/bootstrap-combined.min.css" rel="stylesheet">
     <style type='text/css'>
         @import '../../resources/map/BaseMap.css';
@@ -21,40 +21,52 @@
     </style>
 
     <!-- JAVASCRIPT -->
-    <script type="text/javascript" src="http://serverapi.arcgisonline.com/jsapi/arcgis/3.4/"></script>
+    <script type="text/javascript" src="//js.arcgis.com/3.9"></script>
     <script type="text/javascript">
-        var projectUrl = location.pathname.replace(/\/[^\/]+$/, "") + '/';
+        var projectUrl = location.pathname.replace(/\/[^\/]+$/, '') + '/';
         var baseMap;
 
         require({
             packages: [{
                 name: 'agrc',
                 location: projectUrl + '../..'
+            },{
+                name: 'spin',
+                location: projectUrl + '../../bower_components/spinjs',
+                main: 'spin'
             }]
         },
         [
             'agrc/widgets/map/BaseMap',
 
+            'esri/layers/ArcGISDynamicMapServiceLayer',
+            'esri/geometry/Extent',
+            'esri/SpatialReference',
             'dojo/domReady!'
         ],
 
         function (
-            BaseMap
+            BaseMap,
+
+            ArcGISDynamicMapServiceLayer,
+            Extent,
+            SpatialReference
             ) {
             // take all defaults
             baseMap = new BaseMap('basemap-div');
 
             // add overlay layer
             var overlayBaseMap = new BaseMap('basemap-div-overlay');
-            var lyr = new esri.layers.ArcGISDynamicMapServiceLayer('http://mapserv.utah.gov/ArcGIS/rest/services/Broadband/ProviderCoverage/MapServer', {
+            var lyr = new ArcGISDynamicMapServiceLayer('http://mapserv.utah.gov/ArcGIS/rest/services/' +
+                'Broadband/ProviderCoverage/MapServer', {
                 opacity: 0.75
             });
             overlayBaseMap.addLayer(lyr);
             overlayBaseMap.addLoaderToLayer(lyr);
 
             // custom start extent and base map
-            var startExtent = new esri.geometry.Extent(430481, 4495027, 432392, 4497415,
-                new esri.SpatialReference({
+            var startExtent = new Extent(430481, 4495027, 432392, 4497415,
+                new SpatialReference({
                     wkid: 26912
                 }));
             var options = {
@@ -81,13 +93,13 @@
             loaderBaseMapAerials = new BaseMap('basemap-div-loader-aerials', {
                 'defaultBaseMap': 'Hybrid',
                 'useDefaultExtent': false,
-                'extent': new esri.geometry.Extent({
-                        "xmin": 435525.2820766177,
-                        "ymin": 4503112.014830209,
-                        "xmax": 450812.6877336324,
-                        "ymax": 4522221.271901477,
-                        "spatialReference": {
-                            "wkid": 26912
+                'extent': new Extent({
+                        'xmin': 435525.2820766177,
+                        'ymin': 4503112.014830209,
+                        'xmax': 450812.6877336324,
+                        'ymax': 4522221.271901477,
+                        'spatialReference': {
+                            'wkid': 26912
                         }
                 })
             });

--- a/widgets/tests/spec/SpecBaseMap.js
+++ b/widgets/tests/spec/SpecBaseMap.js
@@ -66,7 +66,7 @@ function (
 
                 var lyrId = map.layerIds[0];
                 var lyr = map.getLayer(lyrId);
-                expect(lyr.url).toEqual('http://mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Vector/MapServer');
+                expect(lyr.url).toEqual('//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Vector/MapServer');
             });
         });
 


### PR DESCRIPTION
We could have done this back in 3.7
[NIM094802](https://developers.arcgis.com/javascript/jshelp/new_v37.html)

We'll want to grunt bump:patch for this before accepting.
