### PR TITLE
Use `window.location.protocol` to set url prefix instead of `//`.

### DIFF
--- a/widgets/locate/FindGeneric.js
+++ b/widgets/locate/FindGeneric.js
@@ -112,7 +112,8 @@ define([
 
         // _searchUrlTemplate: [private] String
         //      the template url to the agrc map service that the validation text box points at;
-        _searchUrlTemplate: '//mapserv.utah.gov/WSUT/GetFeatureAttributes.svc/find-generic-widget/layer' +
+        _searchUrlTemplate: window.location.protocol +
+            '//mapserv.utah.gov/WSUT/GetFeatureAttributes.svc/find-generic-widget/layer' +
             '({layerName})returnAttributes({searchFieldName})where({searchFieldName})(=)( )?dojo',
 
         // _envelopeUrl: [private] String
@@ -121,7 +122,8 @@ define([
 
         // _envelopeUrlTemplate: [private] String
         //      The template url to the agrc map service that returns the feature envelope.
-        _envelopeUrlTemplate: '//mapserv.utah.gov/WSUT/FeatureGeometry.svc/GetEnvelope/find-generic-widget/layer' +
+        _envelopeUrlTemplate: window.location.protocol +
+            '//mapserv.utah.gov/WSUT/FeatureGeometry.svc/GetEnvelope/find-generic-widget/layer' +
             '({layerName})where({searchFieldName})(=)([searchValue])quotes=true',
 
         // _store: dojo.data.Store

--- a/widgets/locate/ZoomToCoords.js
+++ b/widgets/locate/ZoomToCoords.js
@@ -80,7 +80,8 @@ define([
         // summary:
         //      holds urls that are important to this class
         urls: {
-            geometryService: '//mapserv.utah.gov/arcgis/rest/services/Geometry/GeometryServer'
+            geometryService: window.location.protocol +
+                '//mapserv.utah.gov/arcgis/rest/services/Geometry/GeometryServer'
         },
 
         // Properties to be sent into constructor

--- a/widgets/map/BaseMap.js
+++ b/widgets/map/BaseMap.js
@@ -288,7 +288,8 @@ define([
             console.log('agrc.widgets.map.BaseMap::addAGRCBaseMap', arguments);
 
             // build basemap url
-            var url = '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/' + cacheName + '/MapServer';
+            var url = window.location.protocol +
+                '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/' + cacheName + '/MapServer';
             var lyr = new ArcGISTiledMapServiceLayer(url, {
                 id: cacheName
             });

--- a/widgets/map/resources/defaultThemeInfos.js
+++ b/widgets/map/resources/defaultThemeInfos.js
@@ -2,43 +2,43 @@ define([], function() {
         return [{
             label: 'Terrain',
             layers: [{
-                url: '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Terrain/MapServer',
+                url: window.location.protocol + '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Terrain/MapServer',
                 opacity: 1
             }]
         }, {
             label: 'Hybrid',
             layers: [{
-                url: '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Hybrid/MapServer',
+                url: window.location.protocol + '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Hybrid/MapServer',
                 opacity: 1
             }]
         }, {
             label: 'Streets',
             layers: [{
-                url: '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Vector/MapServer',
+                url: window.location.protocol + '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Vector/MapServer',
                 opacity: 1
             }]
         }, {
             label: 'Imagery',
             layers: [{
-                url: '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Imagery/MapServer',
+                url: window.location.protocol + '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Imagery/MapServer',
                 opacity: 1
             }]
         }, {
             label: 'Topo',
             layers: [{
-                url: '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Topo/MapServer',
+                url: window.location.protocol + '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Topo/MapServer',
                 opacity: 1
             }]
         }, {
             label: 'Lite',
             layers: [{
-                url: '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Lite/MapServer',
+                url: window.location.protocol + '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Lite/MapServer',
                 opacity: 1
             }]
         }, {
             label: 'Hillshade',
             layers: [{
-                url: '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Hillshade/MapServer',
+                url: window.location.protocol + '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Hillshade/MapServer',
                 opacity: 1
             }]
         }];

--- a/widgets/tests/BaseMapSelectorTests.html
+++ b/widgets/tests/BaseMapSelectorTests.html
@@ -66,10 +66,10 @@
             var map = new MapDependency('basemap-div', options);
             var map2 = new MapDependency('basemap-div2', options);
 
-            var bbLayer = new LayerDependency('//mapserv.utah.gov/ArcGIS/rest/services/PoliticalDistricts/MapServer', {
+            var bbLayer = new LayerDependency(window.location.protocol + '//mapserv.utah.gov/ArcGIS/rest/services/PoliticalDistricts/MapServer', {
                 opacity: 0.50
             });
-            var hLayer = new TileDependency('//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Hillshade/MapServer');
+            var hLayer = new TileDependency(window.location.protocol + '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Hillshade/MapServer');
 
             //TR, BR, TL, BL
             var selector = new Module({

--- a/widgets/tests/spec/SpecBaseMap.js
+++ b/widgets/tests/spec/SpecBaseMap.js
@@ -66,7 +66,9 @@ function (
 
                 var lyrId = map.layerIds[0];
                 var lyr = map.getLayer(lyrId);
-                expect(lyr.url).toEqual('//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Vector/MapServer');
+                expect(lyr.url).toEqual(
+                    window.location.protocol +
+                    '//mapserv.utah.gov/ArcGIS/rest/services/BaseMaps/Vector/MapServer');
             });
         });
 


### PR DESCRIPTION
This prevents problems with ESRI's `PrintTask` class.
