### PR TITLE
making showLoader optional on this.map

### DIFF
--- a/widgets/locate/TRSsearch.js
+++ b/widgets/locate/TRSsearch.js
@@ -482,7 +482,7 @@ define([
                 if (!self.map.showLoader) {
                     return;
                 }
-                
+
                 if (busy) {
                     self.map.showLoader();
                 } else {

--- a/widgets/locate/TRSsearch.js
+++ b/widgets/locate/TRSsearch.js
@@ -478,6 +478,11 @@ define([
             var self = this;
 
             function showBusy(busy) {
+                // ability to use without agrc.map.BaseMap
+                if (!self.map.showLoader) {
+                    return;
+                }
+                
                 if (busy) {
                     self.map.showLoader();
                 } else {


### PR DESCRIPTION
When you use a vanilla map trs zooming fails. Let's allow it to work everywhere. 🙌