### PR TITLE
Allow for values of zero in zoom to coord widget

### DIFF
--- a/widgets/locate/ZoomToCoords.js
+++ b/widgets/locate/ZoomToCoords.js
@@ -209,7 +209,7 @@ define([
                     return node.name === match;
                 })[0].value;
 
-                return number.parse(value);
+                return number.parse(lang.trim(value));
             };
 
             var inputs = query('[data-required="true"]', this._panelController.visible);
@@ -283,8 +283,9 @@ define([
 
             //filter inputs to get bad ones
             var problems = array.filter(inputs, function (node) {
-                if (!node.value ||
-                    lang.trim(node.value) === '' || !number.parse(node.value)) {
+                var value = lang.trim(node.value);
+                if (!value ||
+                    lang.trim(value) === '' || isNaN(number.parse(value))) {
                     domClass.add(node.parentElement, 'has-error');
                     return true;
                 } else {


### PR DESCRIPTION
For example 112 degrees 0 minutes 0 seconds
Fixes: https://github.com/agrc/deq-spills/issues/46